### PR TITLE
Fix back end tests

### DIFF
--- a/api/config/default.json
+++ b/api/config/default.json
@@ -15,7 +15,7 @@
         "name": "swagger_router",
         "mockMode": false,
         "mockControllersDirs": [
-          "mocks"
+          "mocks/controllers"
         ],
         "controllersDirs": [
           "controllers"

--- a/api/mocks/controllers/client.js
+++ b/api/mocks/controllers/client.js
@@ -29,8 +29,10 @@ module.exports = {
  *        https://github.com/theganyo/swagger-node-runner/issues/79
  */
 function deleteClient (req, res) {
-  if (req.swagger.params.id.value < 100)
+  if (req.swagger.params.id.value > 0)
     res.sendStatus(204);
   else
-    res.sendStatus(404);
+    res.status(404).send({
+      message : 'Trying to update a non-existent client'
+    });
 }

--- a/api/mocks/controllers/client.js
+++ b/api/mocks/controllers/client.js
@@ -32,7 +32,5 @@ function deleteClient (req, res) {
   if (req.swagger.params.id.value > 0)
     res.sendStatus(204);
   else
-    res.status(404).send({
-      message : 'Trying to update a non-existent client'
-    });
+    res.sendStatus(404);
 }

--- a/api/mocks/controllers/client.js
+++ b/api/mocks/controllers/client.js
@@ -1,0 +1,36 @@
+/*
+ * Author : Facundo Victor <facundovt@gmail.com>
+ *
+ * References:
+ *     https://github.com/theganyo/swagger-node-runner/issues/79
+ */
+
+'use strict';
+
+// Exposed methods
+module.exports = {
+  // getAllClients,
+  // getClient,
+  // addClient,
+  // updateClient,
+  deleteClient
+};
+
+
+/*
+ * DELETE /client/{id}
+ *
+ * Remove the client specified by the 'id' parameter.
+ *
+ * This needs to be mocked, because it returns a response with no body, and
+ * this is not supported by the auto-mock provided by swagger.
+ *
+ * Reference:
+ *        https://github.com/theganyo/swagger-node-runner/issues/79
+ */
+function deleteClient (req, res) {
+  if (req.swagger.params.id.value < 100)
+    res.sendStatus(204);
+  else
+    res.sendStatus(404);
+}

--- a/api/mocks/controllers/provider.js
+++ b/api/mocks/controllers/provider.js
@@ -30,7 +30,5 @@ function deleteProvider (req, res) {
   if (req.swagger.params.id.value > 0)
     res.sendStatus(204);
   else
-    res.status(404).send({
-      message : 'Trying to update a non-existent provider'
-    });
+    res.sendStatus(404);
 }

--- a/api/mocks/controllers/provider.js
+++ b/api/mocks/controllers/provider.js
@@ -27,8 +27,10 @@ module.exports = {
  *        https://github.com/theganyo/swagger-node-runner/issues/79
  */
 function deleteProvider (req, res) {
-  if (req.swagger.params.id.value < 100)
+  if (req.swagger.params.id.value > 0)
     res.sendStatus(204);
   else
-    res.sendStatus(404);
+    res.status(404).send({
+      message : 'Trying to update a non-existent provider'
+    });
 }

--- a/api/mocks/controllers/provider.js
+++ b/api/mocks/controllers/provider.js
@@ -1,0 +1,34 @@
+/*
+ * Author : Facundo Victor <facundovt@gmail.com>
+ *
+ * References:
+ *     https://github.com/theganyo/swagger-node-runner/issues/79
+ */
+
+'use strict';
+
+// Exposed methods
+module.exports = {
+  // getAllProviders,
+  // addProvider,
+  // updateProvider,
+  deleteProvider
+};
+
+/*
+ * DELETE /provider/{id}
+ *
+ * Remove the provider specified by the 'id' parameter.
+ *
+ * This needs to be mocked, because it returns a response with no body, and
+ * this is not supported by the auto-mock provided by swagger.
+ *
+ * Reference:
+ *        https://github.com/theganyo/swagger-node-runner/issues/79
+ */
+function deleteProvider (req, res) {
+  if (req.swagger.params.id.value < 100)
+    res.sendStatus(204);
+  else
+    res.sendStatus(404);
+}

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -180,6 +180,10 @@ paths:
           description: Success
           schema:
             $ref: "#/definitions/Client"
+        "404":
+          description: Not Found
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         # responses may fall through to errors
         default:
           description: Error
@@ -280,6 +284,10 @@ paths:
           description: Success
           schema:
             $ref: "#/definitions/Provider"
+        "404":
+          description: Not Found
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         # responses may fall through to errors
         default:
           description: Error

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -99,6 +99,10 @@ paths:
           description: Created
           schema:
             $ref: "#/definitions/Client"
+        "400":
+          description: Bad Request
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         # responses may fall through to errors
         default:
           description: Error
@@ -232,6 +236,10 @@ paths:
           description: Created
           schema:
             $ref: "#/definitions/Provider"
+        "400":
+          description: Bad Request
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         # responses may fall through to errors
         default:
           description: Error

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -180,6 +180,10 @@ paths:
           description: Success
           schema:
             $ref: "#/definitions/Client"
+        "400":
+          description: Bad Request
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         "404":
           description: Not Found
           schema:
@@ -284,6 +288,10 @@ paths:
           description: Success
           schema:
             $ref: "#/definitions/Provider"
+        "400":
+          description: Bad Request
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         "404":
           description: Not Found
           schema:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -334,10 +334,14 @@ definitions:
     properties:
       name:
         type: string
+        maxLength: 50
       email:
         type: string
+        format: email
+        maxLength: 50
       phone:
         type: string
+        maxLength: 50
       providers:
         $ref: "#/definitions/ProvidersWithOptionalName"
 
@@ -363,6 +367,7 @@ definitions:
         type: number
       name:
         type: string
+        maxLength: 50
 
   # Provider structure that requires a name
   Provider:
@@ -375,6 +380,7 @@ definitions:
         type: number
       name:
         type: string
+        maxLength: 50
 
   # New Provider structure
   NewProvider:
@@ -383,6 +389,7 @@ definitions:
     type: object
     properties:
       name:
+        maxLength: 50
         type: string
 
 

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -342,6 +342,7 @@ definitions:
       phone:
         type: string
         maxLength: 50
+        pattern: '^\d{3}-\d{3}-\d{4}$'
       providers:
         $ref: "#/definitions/ProvidersWithOptionalName"
 

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -154,8 +154,6 @@ paths:
           description: No Content
         "404":
           description: Not Found
-          schema:
-            $ref: "#/definitions/ErrorResponse"
         # responses may fall through to errors
         default:
           description: Error
@@ -266,8 +264,6 @@ paths:
           description: No Content
         "404":
           description: Not Found
-          schema:
-            $ref: "#/definitions/ErrorResponse"
         # responses may fall through to errors
         default:
           description: Error

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -119,6 +119,7 @@ paths:
           type: string
           in: path
           required: true
+
       responses:
         "200":
           description: Success
@@ -143,6 +144,7 @@ paths:
           type: string
           in: path
           required: true
+
       responses:
         "204":
           description: No Content
@@ -242,6 +244,7 @@ paths:
           type: string
           in: path
           required: true
+
       responses:
         "204":
           description: No Content
@@ -276,7 +279,7 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: "#/definitions/Client"
+            $ref: "#/definitions/Provider"
         # responses may fall through to errors
         default:
           description: Error

--- a/api/test/controllers/client.js
+++ b/api/test/controllers/client.js
@@ -418,6 +418,21 @@ describe('controllers', function() {
             done();
           });
       });
+
+      it('should return 404 (Not found) on wrong client id', function(done) {
+
+        request(server)
+          .get(`${api_path}client/${wrong_client_id}`)
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '404')
+          .expect(404)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            done();
+          });
+      });
     });
 
     describe(`PUT ${api_path}client/{id}`, function() {

--- a/api/test/controllers/client.js
+++ b/api/test/controllers/client.js
@@ -427,7 +427,6 @@ describe('controllers', function() {
           .set('Content-Type', 'application/json')
           .set('_mockReturnStatus', '404')
           .expect(404)
-          .expect('Content-Type', /json/)
           .end(function(err, res) {
             should.not.exist(err);
             done();

--- a/api/test/controllers/client.js
+++ b/api/test/controllers/client.js
@@ -16,6 +16,9 @@ const request = require('supertest');
 const server = require('../../app');
 const api_path = '/api/';
 
+// Test helpers
+const errorValidator = require('../helpers/error_validations');
+
 // Environment variables
 const isIntegrationTest = process.env.INTEGRATION;
 
@@ -65,10 +68,10 @@ describe('controllers', function() {
         provider_id        = 5,
         wrong_provider_id  = -1,
         client_name        = "Some client",
-        long_string        = new Array(1000).join('a'),
+        long_string        = new Array(60).join('a'),
         wrong_client_name  = long_string,
         client_email       = "some@email.com",
-        wrong_client_email_long   = long_string,
+        wrong_client_email_long   = long_string + "@asdasd.com",
         wrong_client_email_format = "unformated-email",
         client_phone              = "123-123-1546",
         wrong_client_phone_long   = long_string,
@@ -125,6 +128,274 @@ describe('controllers', function() {
             if (isIntegrationTest)
               client_id = res.body.id;
 
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on empty body', function(done) {
+
+        request(server)
+          .post(`${api_path}client`)
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAListOfObjectMissingRequiredErrors(error.errors, [
+              'name', 'email', 'phone', 'providers'
+            ]);
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on missing name', function(done) {
+
+        request(server)
+          .post(`${api_path}client`)
+          .send({
+            email     : client_email,
+            phone     : client_phone,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAnObjectMissingRequiredError(error.errors[0], 'name');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on missing email', function(done) {
+
+        request(server)
+          .post(`${api_path}client`)
+          .send({
+            name      : client_name,
+            phone     : client_phone,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAnObjectMissingRequiredError(error.errors[0], 'email');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on missing phone', function(done) {
+
+        request(server)
+          .post(`${api_path}client`)
+          .send({
+            name      : client_name,
+            email     : client_email,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAnObjectMissingRequiredError(error.errors[0], 'phone');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on missing providers', function(done) {
+
+        request(server)
+          .post(`${api_path}client`)
+          .send({
+            name  : client_name,
+            email : client_email,
+            phone : client_phone,
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAnObjectMissingRequiredError(error.errors[0], 'providers');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on long name', function(done) {
+
+        request(server)
+          .post(`${api_path}client`)
+          .send({
+            name      : wrong_client_name,
+            email     : client_email,
+            phone     : client_phone,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAMaxLengthError(error.errors[0], 'name');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on long email', function(done) {
+
+        request(server)
+          .post(`${api_path}client`)
+          .send({
+            name      : client_name,
+            email     : wrong_client_email_long,
+            phone     : client_phone,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAMaxLengthError(error.errors[0], 'email');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on long phone', function(done) {
+
+        request(server)
+          .post(`${api_path}client`)
+          .send({
+            name      : client_name,
+            email     : client_email,
+            phone     : wrong_client_phone_long,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAMaxLengthError(error.errors[0], 'phone');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on wrong phone', function(done) {
+
+        request(server)
+          .post(`${api_path}client`)
+          .send({
+            name      : client_name,
+            email     : client_email,
+            phone     : wrong_client_phone_format,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAPatternError(error.errors[0], 'phone');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on wrong email', function(done) {
+
+        request(server)
+          .post(`${api_path}client`)
+          .send({
+            name      : client_name,
+            email     : wrong_client_email_format,
+            phone     : client_phone,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAnInvalidFormatError(error.errors[0], 'email');
             done();
           });
       });

--- a/api/test/controllers/client.js
+++ b/api/test/controllers/client.js
@@ -46,7 +46,8 @@ describe('controllers', function() {
 
   describe('client', function() {
 
-    let client_id = 1;
+    let client_id   = 1,
+        provider_id = 5;
 
     describe(`GET ${api_path}client`, function() {
 
@@ -79,7 +80,7 @@ describe('controllers', function() {
             email     : 'some@email.com',
             phone     : '1242342343',
             providers : [{
-              id : 3
+              id : provider_id
             }]
           })
           .set('Accept', 'application/json')
@@ -132,7 +133,7 @@ describe('controllers', function() {
             email     : 'some@email.com',
             phone     : '1242342343',
             providers : [{
-              id : 3
+              id : provider_id
             }]
           })
           .set('Accept', 'application/json')

--- a/api/test/controllers/client.js
+++ b/api/test/controllers/client.js
@@ -461,11 +461,312 @@ describe('controllers', function() {
             done();
           });
       });
+
+      it('Should return 404 (Not found) on invalid client id', function(done) {
+
+        request(server)
+          .put(`${api_path}client/${wrong_client_id}`)
+          .send({
+            id        : wrong_client_id,
+            name      : client_name,
+            email     : client_email,
+            phone     : client_phone,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '404')
+          .expect(404)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on empty body', function(done) {
+
+        request(server)
+          .put(`${api_path}client/${client_id}`)
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAListOfObjectMissingRequiredErrors(error.errors, [
+              'name', 'email', 'phone', 'providers'
+            ]);
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on missing name', function(done) {
+
+        request(server)
+          .put(`${api_path}client/${client_id}`)
+          .send({
+            id        : client_id,
+            email     : client_email,
+            phone     : client_phone,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAnObjectMissingRequiredError(error.errors[0], 'name');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on missing email', function(done) {
+
+        request(server)
+          .put(`${api_path}client/${client_id}`)
+          .send({
+            id        : client_id,
+            name      : client_name,
+            phone     : client_phone,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAnObjectMissingRequiredError(error.errors[0], 'email');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on missing phone', function(done) {
+
+        request(server)
+          .put(`${api_path}client/${client_id}`)
+          .send({
+            id        : client_id,
+            name      : client_name,
+            email     : client_email,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAnObjectMissingRequiredError(error.errors[0], 'phone');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on missing providers', function(done) {
+
+        request(server)
+          .put(`${api_path}client/${client_id}`)
+          .send({
+            id        : client_id,
+            name  : client_name,
+            email : client_email,
+            phone : client_phone,
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAnObjectMissingRequiredError(error.errors[0], 'providers');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on long name', function(done) {
+
+        request(server)
+          .put(`${api_path}client/${client_id}`)
+          .send({
+            id        : client_id,
+            name      : wrong_client_name,
+            email     : client_email,
+            phone     : client_phone,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAMaxLengthError(error.errors[0], 'name');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on long email', function(done) {
+
+        request(server)
+          .put(`${api_path}client/${client_id}`)
+          .send({
+            id        : client_id,
+            name      : client_name,
+            email     : wrong_client_email_long,
+            phone     : client_phone,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAMaxLengthError(error.errors[0], 'email');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on long phone', function(done) {
+
+        request(server)
+          .put(`${api_path}client/${client_id}`)
+          .send({
+            id        : client_id,
+            name      : client_name,
+            email     : client_email,
+            phone     : wrong_client_phone_long,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAMaxLengthError(error.errors[0], 'phone');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on wrong phone', function(done) {
+
+        request(server)
+          .put(`${api_path}client/${client_id}`)
+          .send({
+            id        : client_id,
+            name      : client_name,
+            email     : client_email,
+            phone     : wrong_client_phone_format,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAPatternError(error.errors[0], 'phone');
+            done();
+          });
+      });
+
+      it('Should return 400 (Bad Request) on wrong email', function(done) {
+
+        request(server)
+          .put(`${api_path}client/${client_id}`)
+          .send({
+            id        : client_id,
+            name      : client_name,
+            email     : wrong_client_email_format,
+            phone     : client_phone,
+            providers : [{
+              id : provider_id
+            }]
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAnInvalidFormatError(error.errors[0], 'email');
+            done();
+          });
+      });
     });
 
     describe(`DELETE ${api_path}client/{id}`, function() {
 
-      it('Should return return 204', function(done) {
+      it('Should return 204', function(done) {
 
         request(server)
           .delete(`${api_path}client/${client_id}`)
@@ -476,6 +777,20 @@ describe('controllers', function() {
           .end(function(err, res) {
             should.not.exist(err);
             res.body.should.be.empty();
+            done();
+          });
+      });
+
+      it('Should return 404 (Not found) on wrong client id', function(done) {
+
+        request(server)
+          .delete(`${api_path}client/${wrong_client_id}`)
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '404')
+          .expect(404)
+          .end(function(err, res) {
+            should.not.exist(err);
             done();
           });
       });

--- a/api/test/controllers/client.js
+++ b/api/test/controllers/client.js
@@ -83,6 +83,7 @@ describe('controllers', function() {
             }]
           })
           .set('Accept', 'application/json')
+          .set('_mockReturnStatus', '201')
           .expect(201)
           .expect('Content-Type', /json/)
           .end(function(err, res) {
@@ -153,7 +154,7 @@ describe('controllers', function() {
         request(server)
           .delete(`${api_path}client/${client_id}`)
           .set('Accept', 'application/json')
-          // TODO: Fix the mocked API that is returning 500
+          .set('_mockReturnStatus', '204')
           .expect(204)
           .end(function(err, res) {
             should.not.exist(err);

--- a/api/test/controllers/client.js
+++ b/api/test/controllers/client.js
@@ -30,14 +30,28 @@ const isIntegrationTest = process.env.INTEGRATION;
  * @param client {Object}, Object to validate if it's a client.
  */
 function validateClientWithProvider (client) {
-    client.should.have.property('name');
-    client.should.have.property('email');
-    client.should.have.property('phone');
-    client.should.have.property('providers');
+  client.should.have.property('name');
+  client.name.should.be.an.String();
+  client.name.should.be.not.empty();
+  client.name.length.should.be.belowOrEqual(50);
 
-    client.providers.forEach( provider => {
-        provider.should.have.property('id');
-    });
+  client.should.have.property('email');
+  client.email.should.be.an.String();
+  client.email.should.be.not.empty();
+  client.email.length.should.be.belowOrEqual(50);
+  client.email.should.match(/^[^\s@]+@[^\s@]+\.[^\s@]+$/);
+
+  client.should.have.property('phone');
+  client.phone.should.be.an.String();
+  client.phone.should.be.not.empty();
+  client.phone.length.should.be.belowOrEqual(50);
+  client.phone.should.match(/^\d{3}\-\d{3}\-\d{4}$/);
+
+  client.should.have.property('providers');
+  client.providers.should.be.an.Array();
+  client.providers.forEach( provider => {
+    provider.should.have.property('id');
+  });
 }
 
 /* Tests *********************************************************************/
@@ -46,8 +60,19 @@ describe('controllers', function() {
 
   describe('client', function() {
 
-    let client_id   = 1,
-        provider_id = 5;
+    let client_id          = 1,
+        wrong_client_id    = -1,
+        provider_id        = 5,
+        wrong_provider_id  = -1,
+        client_name        = "Some client",
+        long_string        = new Array(1000).join('a'),
+        wrong_client_name  = long_string,
+        client_email       = "some@email.com",
+        wrong_client_email_long   = long_string,
+        wrong_client_email_format = "unformated-email",
+        client_phone              = "123-123-1546",
+        wrong_client_phone_long   = long_string,
+        wrong_client_phone_format = "12312-412";
 
     describe(`GET ${api_path}client`, function() {
 
@@ -77,9 +102,9 @@ describe('controllers', function() {
         request(server)
           .post(`${api_path}client`)
           .send({
-            name      : 'Some client',
-            email     : 'some@email.com',
-            phone     : '1242342343',
+            name      : client_name,
+            email     : client_email,
+            phone     : client_phone,
             providers : [{
               id : provider_id
             }]
@@ -132,9 +157,9 @@ describe('controllers', function() {
           .put(`${api_path}client/${client_id}`)
           .send({
             id        : client_id,
-            name      : 'Some client',
-            email     : 'some@email.com',
-            phone     : '1242342343',
+            name      : client_name,
+            email     : client_email,
+            phone     : client_phone,
             providers : [{
               id : provider_id
             }]

--- a/api/test/controllers/client.js
+++ b/api/test/controllers/client.js
@@ -56,6 +56,7 @@ describe('controllers', function() {
         request(server)
           .get(`${api_path}client`)
           .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
           .expect(200)
           .expect('Content-Type', /json/)
           .end(function(err, res) {
@@ -84,6 +85,7 @@ describe('controllers', function() {
             }]
           })
           .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
           .set('_mockReturnStatus', '201')
           .expect(201)
           .expect('Content-Type', /json/)
@@ -110,6 +112,7 @@ describe('controllers', function() {
         request(server)
           .get(`${api_path}client/${client_id}`)
           .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
           .expect(200)
           .expect('Content-Type', /json/)
           .end(function(err, res) {
@@ -137,6 +140,7 @@ describe('controllers', function() {
             }]
           })
           .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
           .expect(200)
           .expect('Content-Type', /json/)
           .end(function(err, res) {
@@ -155,6 +159,7 @@ describe('controllers', function() {
         request(server)
           .delete(`${api_path}client/${client_id}`)
           .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
           .set('_mockReturnStatus', '204')
           .expect(204)
           .end(function(err, res) {

--- a/api/test/controllers/provider.js
+++ b/api/test/controllers/provider.js
@@ -254,7 +254,7 @@ describe('controllers', function() {
 
     describe(`DELETE ${api_path}provider/{id}`, function() {
 
-      it('Should return return 204', function(done) {
+      it('Should return return 204 (No content) on success', function(done) {
 
         request(server)
           .delete(`${api_path}provider/${provider_id}`)
@@ -265,6 +265,21 @@ describe('controllers', function() {
           .end(function(err, res) {
             should.not.exist(err);
             res.body.should.be.empty();
+            done();
+          });
+      });
+
+      it('Should return return 404 (Not found) on invalid ID', function(done) {
+
+        request(server)
+          .delete(`${api_path}provider/${wrong_provider_id}`)
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '404')
+          .expect(404)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.have.property('message');
             done();
           });
       });

--- a/api/test/controllers/provider.js
+++ b/api/test/controllers/provider.js
@@ -98,7 +98,7 @@ describe('controllers', function() {
         request(server)
           .put(`${api_path}provider/${provider_id}`)
           .send({
-            id   : 2,
+            id   : provider_id,
             name : 'Some provider',
           })
           .set('Accept', 'application/json')

--- a/api/test/controllers/provider.js
+++ b/api/test/controllers/provider.js
@@ -72,6 +72,7 @@ describe('controllers', function() {
             name : 'Some provider',
           })
           .set('Accept', 'application/json')
+          .set('_mockReturnStatus', '201')
           .expect(201)
           .expect('Content-Type', /json/)
           .end(function(err, res) {

--- a/api/test/controllers/provider.js
+++ b/api/test/controllers/provider.js
@@ -205,6 +205,7 @@ describe('controllers', function() {
           .expect('Content-Type', /json/)
           .end(function(err, res) {
             should.not.exist(err);
+            res.body.should.have.property('message');
             done();
           });
       });

--- a/api/test/controllers/provider.js
+++ b/api/test/controllers/provider.js
@@ -70,7 +70,7 @@ describe('controllers', function() {
         request(server)
           .post(`${api_path}provider`)
           .send({
-            name : 'Some provider',
+            name : 'Some provider'
           })
           .set('Accept', 'application/json')
           .set('_mockReturnStatus', '201')
@@ -100,7 +100,7 @@ describe('controllers', function() {
           .put(`${api_path}provider/${provider_id}`)
           .send({
             id   : provider_id,
-            name : 'Some provider',
+            name : 'Some provider'
           })
           .set('Accept', 'application/json')
           .expect(200)
@@ -113,17 +113,48 @@ describe('controllers', function() {
           });
       });
 
-      it("Should return 404 if the id doesn't exist", function(done) {
+      it("Should return 404 (Not found) if the id doesn't exist", function(done) {
 
         request(server)
           .put(`${api_path}provider/${wrong_provider_id}`)
           .send({
             id   : wrong_provider_id,
-            name : 'Some provider',
+            name : 'Some provider'
           })
           .set('Accept', 'application/json')
           .set('_mockReturnStatus', '404')
           .expect(404)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            done();
+          });
+      });
+
+      it("Should return 400 (Bad Request) on empty request body", function(done) {
+
+        request(server)
+          .put(`${api_path}provider/${provider_id}`)
+          .set('Accept', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            done();
+          });
+      });
+
+      it("Should return 400 (Bad Request) on missing required data", function(done) {
+
+        request(server)
+          .put(`${api_path}provider/${provider_id}`)
+          .send({
+            id   : provider_id
+          })
+          .set('Accept', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
           .expect('Content-Type', /json/)
           .end(function(err, res) {
             should.not.exist(err);

--- a/api/test/controllers/provider.js
+++ b/api/test/controllers/provider.js
@@ -50,6 +50,7 @@ describe('controllers', function() {
         request(server)
           .get(`${api_path}provider`)
           .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
           .expect(200)
           .expect('Content-Type', /json/)
           .end(function(err, res) {
@@ -73,6 +74,7 @@ describe('controllers', function() {
             name : 'Some provider'
           })
           .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
           .set('_mockReturnStatus', '201')
           .expect(201)
           .expect('Content-Type', /json/)
@@ -103,6 +105,7 @@ describe('controllers', function() {
             name : 'Some provider'
           })
           .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
           .expect(200)
           .expect('Content-Type', /json/)
           .end(function(err, res) {
@@ -122,6 +125,7 @@ describe('controllers', function() {
             name : 'Some provider'
           })
           .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
           .set('_mockReturnStatus', '404')
           .expect(404)
           .expect('Content-Type', /json/)
@@ -136,6 +140,7 @@ describe('controllers', function() {
         request(server)
           .put(`${api_path}provider/${provider_id}`)
           .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
           .set('_mockReturnStatus', '400')
           .expect(400)
           .expect('Content-Type', /json/)
@@ -153,6 +158,7 @@ describe('controllers', function() {
             id   : provider_id
           })
           .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
           .set('_mockReturnStatus', '400')
           .expect(400)
           .expect('Content-Type', /json/)
@@ -170,6 +176,7 @@ describe('controllers', function() {
         request(server)
           .delete(`${api_path}provider/${provider_id}`)
           .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
           .set('_mockReturnStatus', '204')
           .expect(204)
           .end(function(err, res) {

--- a/api/test/controllers/provider.js
+++ b/api/test/controllers/provider.js
@@ -229,6 +229,30 @@ describe('controllers', function() {
             done();
           });
       });
+
+      it("Should return 400 (Bad Request) on longer name property", function(done) {
+
+        request(server)
+          .put(`${api_path}provider/${provider_id}`)
+          .send({
+            id   : provider_id,
+            name : wrong_provider_name
+          })
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            errorValidator.shouldBeAValidationError(res.body);
+            let error = res.body.errors[0];
+            errorValidator.shouldBeAnInvalidRequestParameterError(error);
+            errorValidator.shouldBeAMaxLengthError(error.errors[0], 'name');
+            done();
+          });
+      });
     });
 
     describe(`DELETE ${api_path}provider/{id}`, function() {

--- a/api/test/controllers/provider.js
+++ b/api/test/controllers/provider.js
@@ -30,8 +30,63 @@ const isIntegrationTest = process.env.INTEGRATION;
  * @param provider {Object}, Object to validate if it's a provider.
  */
 function validateProvider (provider) {
-    provider.should.have.property('id');
-    provider.should.have.property('name');
+  provider.should.have.property('id');
+  provider.should.have.property('name');
+}
+
+/*
+ * Given a validation error, it validates that it respects the schema
+ *
+ * TODO: Implement this by recovering the schema from swagger, and compare it
+ *       against the real schema.
+ *
+ * @param error {Object}, Object to validate if it's a validation error.
+ */
+function validateValidationError (error) {
+  error.should.have.property('message');
+  error.message.should.be.equal('Validation errors');
+
+  error.should.have.property('errors');
+  error.errors.should.be.an.Array();
+  error.errors.length.should.be.above(0);
+}
+
+/*
+ * Given an invalid request parameter error, it validates that it respects the
+ * schema.
+ *
+ * TODO: Implement this by recovering the schema from swagger, and compare it
+ *       against the real schema.
+ *
+ * @param error {Object}, Object to validate if it's an invalid request para
+ *                        -meter error.
+ */
+function validateInvalidRequestParameterError (error) {
+  error.should.have.property('code');
+  error.should.have.property('errors');
+  error.errors.should.be.an.Array();
+  error.errors.length.should.be.above(0);
+  error.code.should.be.equal('INVALID_REQUEST_PARAMETER');
+
+  error.errors[0].code.should.be.equal('OBJECT_MISSING_REQUIRED_PROPERTY');
+}
+
+/*
+ * Given an missing property error, it validates that it respects the schema.
+ *
+ * TODO: Implement this by recovering the schema from swagger, and compare it
+ *       against the real schema.
+ *
+ * @param error {Object}, Object to validate if it's an object missing required
+ *                        property error.
+ *
+ * @param missingProperty {String}, the name of the missing property.
+ */
+function validateObjectMissingError (error, missingProperty) {
+  error.code.should.be.equal('OBJECT_MISSING_REQUIRED_PROPERTY');
+  error.params.should.be.an.Array();
+  error.params.length.should.be.above(0);
+  error.params.should.containEql(missingProperty);
 }
 
 /* Tests *********************************************************************/

--- a/api/test/controllers/provider.js
+++ b/api/test/controllers/provider.js
@@ -147,6 +147,25 @@ describe('controllers', function() {
             done();
           });
       });
+
+      it('Should return 400 (Bad request) on missing required parameter', function(done) {
+
+        request(server)
+          .post(`${api_path}provider`)
+          .set('Accept', 'application/json')
+          .set('Content-Type', 'application/json')
+          .set('_mockReturnStatus', '400')
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.be.an.Object();
+            validateValidationError(res.body);
+            validateInvalidRequestParameterError(res.body.errors[0]);
+            validateObjectMissingError(res.body.errors[0].errors[0], 'name');
+            done();
+          });
+      });
     });
 
     describe(`PUT ${api_path}provider/{id}`, function() {
@@ -201,6 +220,10 @@ describe('controllers', function() {
           .expect('Content-Type', /json/)
           .end(function(err, res) {
             should.not.exist(err);
+            res.body.should.be.an.Object();
+            validateValidationError(res.body);
+            validateInvalidRequestParameterError(res.body.errors[0]);
+            validateObjectMissingError(res.body.errors[0].errors[0], 'name');
             done();
           });
       });
@@ -219,6 +242,10 @@ describe('controllers', function() {
           .expect('Content-Type', /json/)
           .end(function(err, res) {
             should.not.exist(err);
+            res.body.should.be.an.Object();
+            validateValidationError(res.body);
+            validateInvalidRequestParameterError(res.body.errors[0]);
+            validateObjectMissingError(res.body.errors[0].errors[0], 'name');
             done();
           });
       });

--- a/api/test/controllers/provider.js
+++ b/api/test/controllers/provider.js
@@ -40,7 +40,8 @@ describe('controllers', function() {
 
   describe('provider', function() {
 
-    let provider_id = 1;
+    let provider_id       = 1,
+        wrong_provider_id = -1;
 
     describe(`GET ${api_path}provider`, function() {
 
@@ -107,9 +108,25 @@ describe('controllers', function() {
           .end(function(err, res) {
             should.not.exist(err);
             res.body.should.be.an.Object();
-            // TODO: Fix the mocked api that is returning a client instead of
-            //       a provider.
             validateProvider(res.body);
+            done();
+          });
+      });
+
+      it("Should return 404 if the id doesn't exist", function(done) {
+
+        request(server)
+          .put(`${api_path}provider/${wrong_provider_id}`)
+          .send({
+            id   : wrong_provider_id,
+            name : 'Some provider',
+          })
+          .set('Accept', 'application/json')
+          .set('_mockReturnStatus', '404')
+          .expect(404)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
             done();
           });
       });
@@ -122,7 +139,7 @@ describe('controllers', function() {
         request(server)
           .delete(`${api_path}provider/${provider_id}`)
           .set('Accept', 'application/json')
-          // TODO: Fix the mocked API that is returning 500
+          .set('_mockReturnStatus', '204')
           .expect(204)
           .end(function(err, res) {
             should.not.exist(err);

--- a/api/test/helpers/error_validations.js
+++ b/api/test/helpers/error_validations.js
@@ -1,0 +1,83 @@
+
+/*
+ * Author : Facundo Victor <facundovt@gmail.com>
+ *
+ * List of error validations. The error is formatted on the module
+ * "swagger-node-runner", and the list of errors are part of "sway" (operation
+ * object).
+ *
+ * Reference:
+ *  https://github.com/apigee-127/sway/blob/master/docs/API.md#swayvalidationentry--object
+ *  https://github.com/apigee-127/sway/blob/4c63138d93a47a151c31a636b11c6453c8a4c0a3/test/test-operation.js
+ */
+
+'use strict';
+
+// Exposed methods
+module.exports = {
+  shouldBeAValidationError,
+  shouldBeAnObjectMissingRequiredError,
+  shouldBeAnInvalidRequestParameterError,
+  shouldBeAMaxLengthError
+};
+
+
+/*
+ * Given a validation error, it validates that it respects the schema
+ *
+ * @param error {Object}, Object to validate if it's a validation error.
+ */
+function shouldBeAValidationError (error) {
+  error.should.have.property('message');
+  error.message.should.be.equal('Validation errors');
+
+  error.should.have.property('errors');
+  error.errors.should.be.an.Array();
+  error.errors.length.should.be.above(0);
+}
+
+/*
+ * Given an invalid request parameter error, it validates that it respects the
+ * schema.
+ *
+ * @param error {Object}, Object to validate if it's an invalid request para
+ *                        -meter error.
+ */
+function shouldBeAnInvalidRequestParameterError (error) {
+  error.should.have.property('code');
+  error.should.have.property('errors');
+  error.errors.should.be.an.Array();
+  error.errors.length.should.be.above(0);
+  error.code.should.be.equal('INVALID_REQUEST_PARAMETER');
+}
+
+/*
+ * Given an missing property error, it validates that it respects the schema.
+ *
+ * @param error {Object}, Object to validate if it's an object missing required
+ *                        property error.
+ *
+ * @param missingProperty {String}, the name of the missing property.
+ */
+function shouldBeAnObjectMissingRequiredError (error, missingProperty) {
+  error.code.should.be.equal('OBJECT_MISSING_REQUIRED_PROPERTY');
+  error.params.should.be.an.Array();
+  error.params.length.should.be.above(0);
+  error.params.should.containEql(missingProperty);
+}
+
+/*
+ * Given a Max Length property error, it validates that it respects the schema.
+ *
+ * @param error {Object}, Object to validate if it's a max length error.
+ *
+ * @param propertyInConflict {String}, the name of the missing property.
+ */
+function shouldBeAMaxLengthError (error, propertyInConflict) {
+  error.code.should.be.equal('MAX_LENGTH');
+  error.params.should.be.an.Array();
+  error.params.length.should.be.above(0);
+  error.path.should.be.an.Array();
+  error.path.length.should.be.above(0);
+  error.path.should.containEql(propertyInConflict);
+}

--- a/api/test/helpers/error_validations.js
+++ b/api/test/helpers/error_validations.js
@@ -18,7 +18,10 @@ module.exports = {
   shouldBeAValidationError,
   shouldBeAnObjectMissingRequiredError,
   shouldBeAnInvalidRequestParameterError,
-  shouldBeAMaxLengthError
+  shouldBeAListOfObjectMissingRequiredErrors,
+  shouldBeAnInvalidFormatError,
+  shouldBeAMaxLengthError,
+  shouldBeAPatternError
 };
 
 
@@ -67,6 +70,32 @@ function shouldBeAnObjectMissingRequiredError (error, missingProperty) {
 }
 
 /*
+ * Given a list of missing property errors, it validates that it respects the
+ * schema.
+ *
+ * @param errors {Array}, Array of Objectes to be validated if they are missing
+ *                        required property error.
+ *
+ * @param missingProperties {Array}, the name list of the missing properties.
+ */
+function shouldBeAListOfObjectMissingRequiredErrors (errors, missingProperties) {
+  errors.should.be.an.Array();
+  errors.length.should.be.above(0);
+  missingProperties.should.be.an.Array();
+  missingProperties.length.should.be.above(0);
+  errors.length.should.be.equal(missingProperties.length);
+
+  let listOfMissingParams = errors.map( error => {
+    error.code.should.be.equal('OBJECT_MISSING_REQUIRED_PROPERTY');
+    error.params.should.be.an.Array();
+    error.params.length.should.be.equal(1);
+    return error.params[0];
+  });
+
+  missingProperties.should.containDeep(missingProperties);
+}
+
+/*
  * Given a Max Length property error, it validates that it respects the schema.
  *
  * @param error {Object}, Object to validate if it's a max length error.
@@ -75,6 +104,38 @@ function shouldBeAnObjectMissingRequiredError (error, missingProperty) {
  */
 function shouldBeAMaxLengthError (error, propertyInConflict) {
   error.code.should.be.equal('MAX_LENGTH');
+  error.params.should.be.an.Array();
+  error.params.length.should.be.above(0);
+  error.path.should.be.an.Array();
+  error.path.length.should.be.above(0);
+  error.path.should.containEql(propertyInConflict);
+}
+
+/*
+ * Given a pattern check error, it validates that it respects the schema.
+ *
+ * @param error {Object}, Object to validate if it's a pattern check error.
+ *
+ * @param propertyInConflict {String}, the name of the wrong property.
+ */
+function shouldBeAPatternError (error, propertyInConflict) {
+  error.code.should.be.equal('PATTERN');
+  error.params.should.be.an.Array();
+  error.params.length.should.be.above(0);
+  error.path.should.be.an.Array();
+  error.path.length.should.be.above(0);
+  error.path.should.containEql(propertyInConflict);
+}
+
+/*
+ * Given an Invalid Format error, it validates that it respects the schema.
+ *
+ * @param error {Object}, Object to validate if it's an "Invalid format" error.
+ *
+ * @param propertyInConflict {String}, the name of the wrong property.
+ */
+function shouldBeAnInvalidFormatError (error, propertyInConflict) {
+  error.code.should.be.equal('INVALID_FORMAT');
   error.params.should.be.an.Array();
   error.params.length.should.be.above(0);
   error.path.should.be.an.Array();


### PR DESCRIPTION
Fix the back-end support for testing.

Add the following tests:

```
  controllers
    client
      GET /api/client
        ✓ should return a list of valid clients (54ms)
      POST /api/client
        ✓ Should return a new valid client (57ms)
        ✓ Should return 400 (Bad Request) on empty body
        ✓ Should return 400 (Bad Request) on missing name
        ✓ Should return 400 (Bad Request) on missing email
        ✓ Should return 400 (Bad Request) on missing phone
        ✓ Should return 400 (Bad Request) on missing providers
        ✓ Should return 400 (Bad Request) on long name
        ✓ Should return 400 (Bad Request) on long email
        ✓ Should return 400 (Bad Request) on long phone
        ✓ Should return 400 (Bad Request) on wrong phone
        ✓ Should return 400 (Bad Request) on wrong email
      GET /api/client/{id}
        ✓ should return a valid client
        ✓ should return 404 (Not found) on wrong client id
      PUT /api/client/{id}
        ✓ Should return the modified client
        ✓ Should return 404 (Not found) on invalid client id
        ✓ Should return 400 (Bad Request) on empty body
        ✓ Should return 400 (Bad Request) on missing name
        ✓ Should return 400 (Bad Request) on missing email
        ✓ Should return 400 (Bad Request) on missing phone
        ✓ Should return 400 (Bad Request) on missing providers
        ✓ Should return 400 (Bad Request) on long name
        ✓ Should return 400 (Bad Request) on long email
        ✓ Should return 400 (Bad Request) on long phone
        ✓ Should return 400 (Bad Request) on wrong phone
        ✓ Should return 400 (Bad Request) on wrong email
      DELETE /api/client/{id}
        ✓ Should return 204
        ✓ Should return 404 (Not found) on wrong client id

    provider
      GET /api/provider
        ✓ should return a list of valid providers
      POST /api/provider
        ✓ Should return a new valid provider
        ✓ Should return 400 (Bad request) on missing required parameter
        ✓ Should return 400 (Bad request) on longer name parameter
      PUT /api/provider/{id}
        ✓ Should return the modified provider
        ✓ Should return 404 (Not found) if the id doesn't exist
        ✓ Should return 400 (Bad Request) on empty request body
        ✓ Should return 400 (Bad Request) on missing required data
        ✓ Should return 400 (Bad Request) on longer name property
      DELETE /api/provider/{id}
        ✓ Should return return 204 (No content) on success
        ✓ Should return return 404 (Not found) on invalid ID

  39 passing (578ms)
```